### PR TITLE
Add monitoring stack and volume configuration

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -78,8 +78,8 @@ kueue_default_flavor: "oscar-default-flavor"
 
 # Configure Prometheus
 prometheus_url: ""
-prometheus_cpu_query: 'sum(increase(container_cpu_usage_seconds_total{namespace=~"{{services_namespace}}.*",service=~"{{service}}"}[{{range}}])) / 3600'
-prometheus_gpu_query: 'sum(increase(container_gpu_usage_seconds_total{namespace=~"{{services_namespace}}.*",service=~"{{service}}"}[{{range}}])) / 3600'
+prometheus_cpu_query: "{% raw %}sum(increase(container_cpu_usage_seconds_total{namespace=~\"{{services_namespace}}.*\",service=~\"{{service}}\"}[{{range}}])) / 3600){% endraw %}"
+prometheus_gpu_query: "{% raw %}sum(increase(container_gpu_usage_seconds_total{namespace=~\"{{services_namespace}}.*\",service=~\"{{service}}\"}[{{range}}])) / 3600){% endraw %}"
 
 # Configure Loki
 loki_url: ""


### PR DESCRIPTION
## Summary
- Add monitoring stack with Prometheus, Grafana, Loki, and Promtail
- Add KUBECONFIG environment variable to all kubectl and helm commands
- Add --create-namespace to all Helm commands
- Wrap prometheus queries in raw block to prevent Ansible variable substitution