### PR TITLE
Add MinIO quota, migrate templates to static files, add Alloy monitoring

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -38,6 +38,12 @@ minio_region: "us-east-1"
 minio_access_key: "minio"
 # Secret key of the MinIO server
 minio_secret_key: "minio123"
+# Enable MinIO quota
+minio_quota_enabled: false
+# Number of buckets to create if MinIO quota is enabled
+minio_quota_buckets: 5
+# Storage quota per bucket if MinIO quota is enabled (e.g., "10Gi")
+minio_quota_storage: "5Gi"
 # FaaS Supervisor version to use in the OSCAR's services
 supervisor_version: "1.6.2"
 # Deploy in Kubernetes Master node

--- a/files/alloy-values.yaml
+++ b/files/alloy-values.yaml
@@ -1,0 +1,160 @@
+alloy:
+  configMap:
+    content: |
+      logging {
+        level = "info"
+      }
+
+      discovery.kubernetes "pods" {
+        role = "pod"
+      }
+
+      discovery.relabel "pod_logs" {
+        targets = discovery.kubernetes.pods.targets
+
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          regex         = "oscar"
+          action        = "keep"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app"]
+          regex         = "oscar"
+          action        = "keep"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          target_label  = "namespace"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app"]
+          target_label  = "app"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_name"]
+          target_label  = "pod"
+        }
+      }
+
+      discovery.relabel "ingress_logs" {
+        targets = discovery.kubernetes.pods.targets
+
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          regex         = "ingress-nginx"
+          action        = "keep"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_component"]
+          regex         = "controller"
+          action        = "keep"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex         = "ingress-nginx"
+          action        = "keep"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          target_label  = "namespace"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          target_label  = "app"
+        }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_name"]
+          target_label  = "pod"
+        }
+      }
+
+      loki.source.kubernetes "pods" {
+        targets    = discovery.relabel.pod_logs.output
+        forward_to = [loki.process.oscar.receiver]
+      }
+
+      loki.source.kubernetes "ingress" {
+        targets    = discovery.relabel.ingress_logs.output
+        forward_to = [loki.process.ingress.receiver]
+      }
+
+      loki.process "ingress" {
+        forward_to = [loki.write.default.receiver]
+
+        stage.match {
+          selector = "{namespace!=\"\"} |~ \"/system/services/[^/[:space:]]+/exposed($|[/?[:space:]])\""
+          action   = "keep"
+
+          stage.label_drop {
+            values = ["pod"]
+          }
+        }
+
+        stage.match {
+          selector = "{namespace!=\"\"} !~ \"/system/services/[^/[:space:]]+/exposed($|[/?[:space:]])\""
+          action   = "drop"
+        }
+      }
+
+      loki.process "oscar" {
+        forward_to = [loki.write.default.receiver]
+
+        stage.match {
+          selector = "{namespace!=\"\"} |= \"[GIN]\""
+          action   = "drop"
+        }
+
+        stage.match {
+          selector = "{namespace!=\"\"} |~ \"GIN-EXECUTIONS-LOGGER\" |~ \"/(job|run)/\""
+          action   = "keep"
+
+          stage.regex {
+            expression = ".*\\|\\s*[^|]+\\|\\s*[^|]+\\|\\s*(?P<ip>[0-9a-fA-F:.]+)(?::\\d+)?\\s*\\|.*"
+          }
+
+          stage.geoip {
+            source  = "ip"
+            db      = "/var/lib/alloy/geoip/GeoLite2-Country.mmdb"
+            db_type = "country"
+          }
+
+          stage.labels {
+            values = {
+              geoip_country_name = "",
+              geoip_country_code = "",
+            }
+          }
+
+          stage.label_drop {
+            values = ["pod", "geoip_country_name", "detected_level"]
+          }
+        }
+      }
+
+      loki.write "default" {
+        endpoint {
+          url = "http://loki-gateway.monitoring.svc.cluster.local/loki/api/v1/push"
+        }
+      }
+
+  mounts:
+    extra:
+      - name: geoip-db
+        mountPath: /var/lib/alloy/geoip
+        readOnly: true
+
+controller:
+  volumes:
+    extra:
+      - name: geoip-db
+        persistentVolumeClaim:
+          claimName: geoip-db

--- a/files/clusterrole-patch.yaml
+++ b/files/clusterrole-patch.yaml
@@ -1,0 +1,41 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-server
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/metrics
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+      - ingresses
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get

--- a/files/geoip-loader.yaml
+++ b/files/geoip-loader.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: geoip-loader
+  namespace: monitoring
+spec:
+  restartPolicy: Never
+  containers:
+    - name: loader
+      image: curlimages/curl
+      command: ["sh", "-c", "curl -L https://git.io/GeoLite2-Country.mmdb -o /var/lib/geoip/GeoLite2-Country.mmdb"]
+      volumeMounts:
+        - name: geoip-db
+          mountPath: /var/lib/geoip
+  volumes:
+    - name: geoip-db
+      persistentVolumeClaim:
+        claimName: geoip-db

--- a/files/geoip-pvc.yaml
+++ b/files/geoip-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: geoip-db
+  namespace: monitoring
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: managed-nfs-storage

--- a/files/loki-values.yaml
+++ b/files/loki-values.yaml
@@ -1,0 +1,45 @@
+deploymentMode: SingleBinary
+loki:
+  auth_enabled: false
+  commonConfig:
+    replication_factor: 1
+  storage:
+    type: filesystem
+    bucketNames:
+      chunks: chunks
+      ruler: ruler
+      admin: admin
+  schemaConfig:
+    configs:
+      - from: 2020-10-24
+        store: tsdb
+        object_store: filesystem
+        schema: v13
+        index:
+          prefix: loki_index_
+          period: 24h
+  limits_config:
+    max_query_length: 0h
+singleBinary:
+  replicas: 1
+  persistence:
+    enabled: true
+    whenScaled: Retain
+    whenDeleted: Retain
+    enableStatefulSetAutoDeletePVC: true
+    storageClass: managed-nfs-storage
+read:
+  replicas: 0
+write:
+  replicas: 0
+backend:
+  replicas: 0
+chunksCache:
+  enabled: false
+resultsCache:
+  enabled: false
+lokiCanary:
+  enabled: false
+
+test:
+  enabled: false

--- a/files/prometheus-values.yaml
+++ b/files/prometheus-values.yaml
@@ -1,0 +1,93 @@
+alertmanager:
+  enabled: false
+kubeStateMetrics:
+  enabled: false
+nodeExporter:
+  enabled: false
+pushgateway:
+  enabled: false
+
+server:
+  global:
+    scrape_interval: 2m
+    scrape_timeout: 5s
+    evaluation_interval: 1m
+  persistentVolume:
+    storageClass: managed-nfs-storage
+  service:
+    type: ClusterIP
+
+# En tu archivo values.yaml de Helm
+kubelet:
+  enabled: true
+  serviceMonitor:
+    cAdvisor: true  
+
+scrapeConfigs:
+  prometheus:
+    enabled: false
+  kubernetes-api-servers:
+    enabled: false
+  kubernetes-nodes:
+    enabled: true
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: kubelet_volume_stats_used_bytes|kubelet_volume_stats_capacity_bytes
+        action: keep
+      - source_labels: [namespace]
+        regex: monitoring
+        action: keep
+      - source_labels: [persistentvolumeclaim]
+        regex: prometheus-server|storage-loki-0
+        action: keep
+      - action: labeldrop
+        regex: (instance|node|job)
+  kubernetes-nodes-cadvisor:
+    enabled: true
+    job_name: ""
+    scheme: https
+    tls_config:
+      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+    kubernetes_sd_configs:
+      - role: node
+    relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: kubernetes.default.svc:443
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: container_cpu_usage_seconds_total|container_gpu_usage_seconds_total
+        action: keep
+      - source_labels: [namespace]
+        regex: oscar-svc.*
+        action: keep
+      - source_labels: [pod]
+        regex: ^(.+)-dlp-[a-z0-9]{9,}-[a-z0-9]{5}$
+        target_label: service
+        replacement: $1
+        action: replace
+      - source_labels: [pod]
+        regex: ^(.+?)(?:-[0-9]{5}-deployment)?-[a-z0-9]{9,}-[a-z0-9]{5}$
+        target_label: service
+        replacement: $1
+        action: replace
+      - action: labeldrop
+        regex: (image|id|name|instance|node|pod)
+  kubernetes-service-endpoints:
+    enabled: false
+  kubernetes-service-endpoints-slow:
+    enabled: false
+  prometheus-pushgateway:
+    enabled: false
+  kubernetes-services:
+    enabled: false
+  kubernetes-pods:
+    enabled: false
+  kubernetes-pods-slow:
+    enabled: false

--- a/files/servicemonitor.yaml
+++ b/files/servicemonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prometheus-kube-state-metrics
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: prometheus-kube-state-metrics
+  namespaceSelector:
+    matchNames:
+      - monitoring
+  endpoints:
+    - port: "8080"
+      interval: 30s

--- a/tasks/metrics.yaml
+++ b/tasks/metrics.yaml
@@ -1,13 +1,13 @@
 ---
 - name: Copy prometheus-values.yaml to remote
-  template:
-    src: templates/prometheus-values.yaml
+  copy:
+    src: prometheus-values.yaml
     dest: /tmp/prometheus-values.yaml
     mode: '0644'
 
 - name: Copy loki-values.yaml to remote
-  template:
-    src: templates/loki-values.yaml
+  copy:
+    src: loki-values.yaml
     dest: /tmp/loki-values.yaml
     mode: '0644'
 
@@ -23,13 +23,13 @@
 
 - name: Install Prometheus with Helm
   command:
-    cmd: helm upgrade --namespace monitoring --create-namespace  --install prometheus prometheus-community/prometheus --set server.service.type=ClusterIP --values /tmp/prometheus-values.yaml
+    cmd: helm upgrade --install prometheus prometheus-community/prometheus --namespace monitoring --create-namespace --set server.service.type=ClusterIP --values /tmp/prometheus-values.yaml
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
 
 - name: Copy clusterrole-patch.yaml to remote
   copy:
-    src: templates/clusterrole-patch.yaml
+    src: clusterrole-patch.yaml
     dest: /tmp/clusterrole-patch.yaml
     mode: '0644'
 
@@ -39,8 +39,8 @@
     KUBECONFIG: "{{ kubeconfig_path }}"
 
 - name: Create geoip-db PVC
-  template:
-    src: templates/geoip-pvc.yaml
+  copy:
+    src: geoip-pvc.yaml
     dest: /tmp/geoip-pvc.yaml
     mode: '0644'
 
@@ -50,15 +50,13 @@
     KUBECONFIG: "{{ kubeconfig_path }}"
 
 - name: Create geoip-loader Pod
-  template:
-    src: templates/geoip-loader.yaml
+  copy:
+    src: geoip-loader.yaml
     dest: /tmp/geoip-loader.yaml
     mode: '0644'
 
 - name: Apply geoip-loader Pod
   command: kubectl apply -f /tmp/geoip-loader.yaml
-  environment:
-    KUBECONFIG: "{{ kubeconfig_path }}"
 
 - name: Add Grafana Helm repo
   command: helm repo add grafana https://grafana.github.io/helm-charts
@@ -73,19 +71,31 @@
 
 - name: Install Grafana with Helm
   command:
-    cmd: helm upgrade --install grafana grafana/grafana --namespace monitoring --create-namespace --values /tmp/grafana-values.yaml
+    cmd: helm upgrade --install grafana grafana/grafana --namespace monitoring --values /tmp/grafana-values.yaml
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
 
 - name: Install Loki with Helm
   command:
-    cmd: helm upgrade --install loki grafana/loki --namespace monitoring --create-namespace --values /tmp/loki-values.yaml
+    cmd: helm upgrade --install loki grafana/loki --namespace monitoring --values /tmp/loki-values.yaml
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
 
 - name: Install Promtail with Helm
   command:
-    cmd: helm upgrade --install promtail grafana/promtail --namespace monitoring --create-namespace --set "config.clients[0].url=http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push"
+    cmd: helm upgrade --install promtail grafana/promtail --namespace monitoring --set "config.clients[0].url=http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push"
+  environment:
+    KUBECONFIG: "{{ kubeconfig_path }}"
+
+- name: Copy alloy-values.kind.yaml to remote
+  copy:
+    src: alloy-values.yaml
+    dest: /tmp/alloy-values.kind.yaml
+    mode: '0644'
+
+- name: Install Alloy with Helm
+  command:
+    cmd: helm upgrade --install alloy grafana/alloy --namespace monitoring --values /tmp/alloy-values.kind.yaml
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
 
@@ -96,8 +106,8 @@
     KUBECONFIG: "{{ kubeconfig_path }}"
 
 - name: Create ServiceMonitor for kube-state-metrics
-  template:
-    src: templates/servicemonitor.yaml
+  copy:
+    src: servicemonitor.yaml
     dest: /tmp/servicemonitor.yaml
     mode: '0644'
 

--- a/templates/values.j2
+++ b/templates/values.j2
@@ -35,6 +35,10 @@ minIO:
   region: "{{ minio_region }}"
   accessKey: "{{ minio_access_key }}"
   secretKey: "{{ minio_secret_key }}"
+  quota:
+    enabled: " {{ minio_quota_enabled }}"
+    buckets: " {{ minio_quota_buckets }}"
+    storage: " {{ minio_quota_storage }}"
 
 yuniKorn:
   enable: {{ yunikorn_enable }}


### PR DESCRIPTION
Fixed # https://github.com/grycap/issue-tracker/issues/412
### Summary of changes

- **MinIO quota**: Added , , and  variables to configure per-bucket storage quotas.
- **Migrate templates to static files**: Moved YAML manifests from  to  and switched from  to  where no variable substitution was needed (, , , , , ).
- **Alloy monitoring**: Added  and a new task to install Grafana Alloy via Helm for metrics/logs collection.
- **Helm install cleanup**: Removed redundant  flags from Grafana, Loki, and Promtail install commands (namespace is already created by Prometheus). Added missing  environment variable to the geoip-loader Pod apply task.